### PR TITLE
Make the declared version 1.3.1

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	VERSION = "1.2.0"
+	VERSION = "1.3.0"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	VERSION = "1.3.0"
+	VERSION = "1.3.1"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	VERSION = "1.0.0"
+	VERSION = "1.2.0"
 )
 
 var (


### PR DESCRIPTION
(Same as the current "release", not sure if the value should be incremented)

What I get now with the current `master` built from source:

```
#  /usr/local/bin/solidfire-docker-driver -v
solidfire version 1.0.0
```
