### PR TITLE
Fix cosmetic error during initial install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,9 @@ BIN_DIR="/usr/bin"
 
 do_install() {
 mkdir -p /var/lib/solidfire/mount
-rm $BIN_DIR/$BIN_NAME || true
+if [ -f $BIN_DIR/$BIN_NAME ] ; then
+    rm $BIN_DIR/$BIN_NAME || true
+fi
 curl -sSL -o $BIN_DIR/$BIN_NAME $DRIVER_URL
 chmod +x $BIN_DIR/$BIN_NAME
 echo "


### PR DESCRIPTION
```
# bash install.sh
rm: cannot remove ‘/usr/bin/solidfire-docker-driver’: No such file or directory
```
