### PR TITLE
Fix missing include of strconv

### DIFF
--- a/sfapi/api.go
+++ b/sfapi/api.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"strconv"
 )
 
 type Client struct {


### PR DESCRIPTION
I don't know how this slipped through the cracks, but it did. Here's the fix.